### PR TITLE
CI:Resolve workflow syntax error for 'semgrep' input

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -2,9 +2,9 @@ name: Qualcomm Preflight Checks
 
 on:
   pull_request_target:
-    branches: [ master ]
+    branches: [ sem-graph ]
   push:
-    branches: [ master ]
+    branches: [ sem-graph ]
   workflow_dispatch:
 
 permissions:
@@ -14,4 +14,5 @@ permissions:
 jobs:
   qcom-preflight-checks:
     uses: Audioreach/audioreach-workflows/.github/workflows/qcom-preflight-checks.yml@master
-    semgrep: false
+    with:
+      semgrep: false


### PR DESCRIPTION
Resolve invalid workflow file error by correctly passing
'semgrep' as input to reusable workflow via 'with' block.