### PR TITLE
CI: Fix syntax error in preflight checks

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -14,4 +14,5 @@ permissions:
 jobs:
   qcom-preflight-checks:
     uses: Audioreach/audioreach-workflows/.github/workflows/qcom-preflight-checks.yml@master
-    semgrep: false
+    with:
+      semgrep: false


### PR DESCRIPTION
Correct invalid workflow configuration by passing 'semgrep' input via
'with' block in preflight checks. This resolves the error caused by
unexpected key placement.