### PR TITLE
CI: Disable armor checkers in qcom preflight workflow

### DIFF
--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -16,3 +16,4 @@ jobs:
     uses: Audioreach/audioreach-workflows/.github/workflows/qcom-preflight-checks.yml@master
     with:
       enable-semgrep-scan: false
+      enable-armor-checkers: false


### PR DESCRIPTION
This repository contains documentation only, so armor checkers are not applicable.