### PR TITLE
dev/alsalib doc: Fix BitBake append override syntax.

### DIFF
--- a/source/dev/alsalib_using_audioreach.rst
+++ b/source/dev/alsalib_using_audioreach.rst
@@ -69,8 +69,8 @@ Add the following configuration to ``<yocto_build_root>/build/conf/local.conf`` 
 
 .. code-block:: bash
 
-    EXTRA_OECONF:pn-audioreach-graphmgr:append = " --enable-alsalib"
-    EXTRA_OECONF:pn-audioreach-conf:append = " --with-libalsa"
+    EXTRA_OECONF:append:pn-audioreach-graphmgr = " --enable-alsalib"
+    EXTRA_OECONF:append:pn-audioreach-conf = " --with-libalsa"
 
 **Autotools Build**
 


### PR DESCRIPTION
Current EXTRA_OECONF examples used outdated override ordering. With that syntax, append handling was incorrect and existing configuration values could be overwritten.

Update examples to use append:pn-* so flags are appended for audioreach-graphmgr and audioreach-conf.