### PR TITLE
i.MX8MP evk doc update

### DIFF
--- a/source/platform/nxp.rst
+++ b/source/platform/nxp.rst
@@ -106,6 +106,7 @@ AudioReach components in the full Yocto build:
 
    IMAGE_INSTALL:append = "audioreach-graphservices tinyalsa audioreach-graphmgr audioreach-conf audioreach-kernel"
    PACKAGECONFIG:pn-audioreach-graphmgr = "use_default_acdb_path"
+   PACKAGECONFIG:append:pn-audioreach-graphservices = " audio_dma_support"
    EXTRA_OECONF:append:pn-audioreach-conf = " --with-nxp"
 
 Once the configuration is complete, run the following command to generate the full build with

--- a/source/platform/nxp.rst
+++ b/source/platform/nxp.rst
@@ -109,6 +109,26 @@ AudioReach components in the full Yocto build:
    PACKAGECONFIG:append:pn-audioreach-graphservices = " audio_dma_support"
    EXTRA_OECONF:append:pn-audioreach-conf = " --with-nxp"
 
+Before running the final build, apply the following change to the Linux kernel device tree.
+The ``audioreach-kernel`` package includes the ``q6apm_audio_mem`` driver, which manages shared
+memory between the APPS processor and the ADSP. This driver probes on the ``qcom,q6apm-dais``
+compatible string to enable the audio memory device node.
+
+Use ``devtool modify`` to check out the kernel source into the workspace:
+
+.. code-block:: bash
+
+   devtool modify virtual/kernel
+
+In ``<yocto_build_root>/sources/linux-imx/arch/arm64/boot/dts/freescale/imx8mp-evk-dsp.dts``,
+add the following inside the root ``/ { }`` block:
+
+.. code-block:: dts
+
+   q6apmdai: dais {
+      compatible = "qcom,q6apm-dais";
+   };
+
 Once the configuration is complete, run the following command to generate the full build with
 the integrated AudioReach components:
 


### PR DESCRIPTION
- Add the missing audio_dma_support PACKAGECONFIG line for audioreach-graphservices in the local.conf configuration block. This option enables DMA-based shared memory support between the APPS processor and the ADSP on the i.MX8M Plus platform.
- Add a new step to modify the Linux kernel device tree before the final Yocto build. The audioreach-kernel package includes the q6apm_audio_mem driver which probes on the qcom,q6apm-dais compatible string to enable the audio memory device node. 