### PR TITLE
audioreach-doc: update page depth of development workflow

### DIFF
--- a/source/dev/dev_workflow.rst
+++ b/source/dev/dev_workflow.rst
@@ -5,7 +5,6 @@ Development Workflow
 
 .. toctree::
    :maxdepth: 1
-   :hidden:
 
    adding_modules
    capi_mod_dev

--- a/source/dev/index.rst
+++ b/source/dev/index.rst
@@ -4,7 +4,7 @@ AudioReach Developer Guides
 ##################################################
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    dev_workflow
    plat_port


### PR DESCRIPTION
Today, readers may not realize that the Development Workflow page contains subpages for the CAPI Module Development Guide when they click the AudioReach Developer Guides link. Update the page hierarchy and unhide the subpage titles to improve visibility and navigation